### PR TITLE
manifest: add release-test tier + skip no-op rebuilds

### DIFF
--- a/manifest/README.md
+++ b/manifest/README.md
@@ -12,17 +12,26 @@ diagnostics — roughly **400 requests per menu build**. A consumer can now fetc
 
 ## Files / tiers
 
-| File | Layout source | `.pbs` source | Purpose |
-|------|---------------|---------------|---------|
-| `manifest-release.json` | `btn/-button-layout-release.txt` | `pbs-release/` | Public menu (`Use_Beta_Layout=false`, `Enable_Test_Mode=false`) |
-| `manifest-beta.json` | `btn/-button-layout-beta.txt` | `pbs-release/` | David's staging layout (`Use_Beta_Layout=true`) |
-| `manifest-test.json` | `btn/-button-layout-beta.txt` | `pbs-release/` + `pbs-test/` | Bleeding edge + `[TEST]` section (`Enable_Test_Mode=true`) |
+The extension's two toggles (`Use_Beta_Layout`, `Enable_Test_Mode`) are
+orthogonal, so there are **4 combinations — one manifest each:**
 
-> The extension's two toggles (`Use_Beta_Layout`, `Enable_Test_Mode`) are
-> orthogonal — 4 combinations exist. These 3 tiers cover the ones actually used;
-> if a fourth (release-layout + test-pbs) is wanted, add it to `TIERS` in the
-> generator. **This mapping is the one open design choice — confirm before the
-> consumers depend on it.**
+| File | `Use_Beta_Layout` | `Enable_Test_Mode` | Layout source | `.pbs` source | Purpose |
+|------|:---:|:---:|---------------|---------------|---------|
+| `manifest-release.json` | false | false | `btn/-button-layout-release.txt` | `pbs-release/` | Public menu (what the picker uses by default) |
+| `manifest-beta.json` | true | false | `btn/-button-layout-beta.txt` | `pbs-release/` | David's staging layout |
+| `manifest-test.json` | true | true | `btn/-button-layout-beta.txt` | `pbs-release/` + `pbs-test/` | Beta layout + `[TEST]` section (bleeding edge) |
+| `manifest-release-test.json` | false | true | `btn/-button-layout-release.txt` | `pbs-release/` + `pbs-test/` | Release layout with test scenarios previewed |
+
+A consumer maps its two toggle checkboxes straight to the tier: pick the file
+whose `Use_Beta_Layout`/`Enable_Test_Mode` columns match. Any tier that includes
+`pbs-test/` (`test`, `release-test`) also carries a `testScenarios` list of the
+`pbs-test`-only scenarios; where a scenario exists in both, the `pbs-test`
+version overrides `pbs-release`.
+
+> Added `release-test` (PBS #167 follow-up): resolves the previously-open "4th
+> combination" design choice — all four toggle states now have a manifest.
+> Tiers are keyed by name (`release`/`beta`/`test`/`release-test`); the existing
+> three are byte-for-byte unchanged (the BBO extension keeps working).
 
 ## Schema (`schemaVersion: 1`)
 
@@ -64,7 +73,7 @@ diagnostics — roughly **400 requests per menu build**. A consumer can now fetc
   },
   "counts": { "referenced": 334, "scenarios": 334, "missing": 0, "orphans": 0 },
 
-  // test tier only:
+  // test-mode tiers only (test, release-test):
   "testScenarios": [ { "name": "Found_Endplay", "buttonText": "...", "chat": "...", ... } ]
 }
 ```
@@ -83,7 +92,7 @@ extension) with one manifest fetch:
 |-------|----------------------|
 | Fetch `btn/-button-layout-{release,beta}.txt` | `manifest.layout` |
 | Fetch `pbs-<tier>/<name>.pbs` per button for text/chat/alias/style | `manifest.scenarios[name]` |
-| GitHub-API list `pbs-test/` for the `[TEST]` section | `manifest.testScenarios` (test tier) |
+| GitHub-API list `pbs-test/` for the `[TEST]` section | `manifest.testScenarios` (test / release-test tiers) |
 | Per-button 404 check → MISSING PBS FILES | `manifest.deltas.missing` / `scenarios[name].missing` |
 | GitHub-API list `pbs-release/` → ORPHAN SCENARIOS | `manifest.deltas.orphans` |
 | (unavailable) gib-works / bba-works | `scenarios[name].gibWorks` / `.bbaWorks` |

--- a/py/build_manifest.py
+++ b/py/build_manifest.py
@@ -436,6 +436,21 @@ def main():
               + (f" testOnly={c.get('testOnly')}" if "testOnly" in c else ""))
         if not args.check:
             path = os.path.join(out_dir, f"manifest-{tier}.json")
+            # Preserve the prior generatedAtCommit when nothing else changed, so a
+            # rebuild triggered by an unrelated input edit doesn't churn the file.
+            # generatedAtCommit then means "commit where this content last changed",
+            # and the CI commit-gate (git status --porcelain) skips no-op rebuilds
+            # instead of committing a SHA-only diff every push.
+            if os.path.exists(path):
+                try:
+                    with open(path, encoding="utf-8") as fh:
+                        old = json.load(fh)
+                    old_sha = old.pop("generatedAtCommit", None)
+                    if old_sha is not None and old == {k: v for k, v in m.items()
+                                                       if k != "generatedAtCommit"}:
+                        m["generatedAtCommit"] = old_sha
+                except Exception:
+                    pass
             with open(path, "w", encoding="utf-8") as fh:
                 json.dump(m, fh, ensure_ascii=False, indent=2, sort_keys=False)
                 fh.write("\n")

--- a/py/build_manifest.py
+++ b/py/build_manifest.py
@@ -23,6 +23,11 @@ Layout plugin's Use_Beta_Layout / Enable_Test_Mode toggles):
   beta    : -button-layout-beta.txt     +  pbs-release/
   test    : -button-layout-beta.txt     +  pbs-release/ and pbs-test/
             (adds a testScenarios list for the [TEST: pbs-test/] section)
+  release-test : -button-layout-release.txt + pbs-release/ and pbs-test/
+            (the 4th toggle combination: release layout with test mode on)
+
+The two extension toggles (Use_Beta_Layout, Enable_Test_Mode) are orthogonal —
+these four tiers are the four combinations. See the TIERS table below.
 
 Pure stdlib so it runs unchanged in GitHub Actions (ubuntu) and on the Mac.
 Layout / btn parsing lineage: build-scripts-mac/build_pbs_from_layout.py.
@@ -46,10 +51,22 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BTN_DIR = os.path.join(ROOT, "btn")
 
 # tier -> (layout filename, list of pbs source dirs [primary first])
+#
+# The extension's two toggles are orthogonal, giving 4 combinations; each tier
+# below is one of them (Use_Beta_Layout selects the layout file, Enable_Test_Mode
+# adds pbs-test/ as an override source + a testScenarios list):
+#
+#   tier          | Use_Beta_Layout | Enable_Test_Mode | layout   | pbs sources
+#   ------------- | --------------- | ---------------- | -------- | ----------------------
+#   release       | false           | false            | release  | pbs-release
+#   beta          | true            | false            | beta     | pbs-release
+#   test          | true            | true             | beta     | pbs-release + pbs-test
+#   release-test  | false           | true             | release  | pbs-release + pbs-test
 TIERS = {
-    "release": ("-button-layout-release.txt", ["pbs-release"]),
-    "beta":    ("-button-layout-beta.txt",    ["pbs-release"]),
-    "test":    ("-button-layout-beta.txt",    ["pbs-release", "pbs-test"]),
+    "release":      ("-button-layout-release.txt", ["pbs-release"]),
+    "beta":         ("-button-layout-beta.txt",    ["pbs-release"]),
+    "test":         ("-button-layout-beta.txt",    ["pbs-release", "pbs-test"]),
+    "release-test": ("-button-layout-release.txt", ["pbs-release", "pbs-test"]),
 }
 
 
@@ -381,8 +398,9 @@ def build_tier(tier, btn_meta):
         },
     }
 
-    # test tier: expose the pbs-test-only scenarios for the [TEST] section.
-    if tier == "test":
+    # Any test-mode tier (pbs-test in its sources): expose the pbs-test-only
+    # scenarios for the [TEST] section. Same output as before for `test`.
+    if "pbs-test" in pbs_dirs:
         test_only = sorted(n for n in per_dir.get("pbs-test", {})
                            if n not in per_dir.get("pbs-release", {}))
         manifest["testScenarios"] = [


### PR DESCRIPTION
Two related manifest changes.

## 1. Add the `release-test` tier (4th toggle combination) — Closes #167

The extension's two toggles are orthogonal → 4 combinations; now one manifest each:

| tier | `Use_Beta_Layout` | `Enable_Test_Mode` | layout | pbs |
|---|:---:|:---:|---|---|
| release | false | false | release | pbs-release |
| beta | true | false | beta | pbs-release |
| test | true | true | beta | pbs-release + pbs-test |
| **release-test (new)** | false | true | release | pbs-release + pbs-test |

- `TIERS` gains `release-test`.
- `testScenarios` now keys on `"pbs-test" in pbs_dirs` (not `tier == "test"`), so it
  applies to any test-mode tier; the `test` tier's output is unchanged.
- `manifest/README.md` documents all four tiers as the 2×2 toggle matrix.

## 2. Skip no-op manifest rebuilds

The `build-manifest` Action's "commit only if changed" gate was defeated by the
`generatedAtCommit` stamp — every run wrote the new SHA, so it committed a
SHA-only diff on **every** btn/pbs push. The generator now **preserves the prior
`generatedAtCommit` when a manifest's content is otherwise unchanged**, so no-op
rebuilds leave the file byte-identical and the gate skips them. `generatedAtCommit`
now means "the commit where this tier's content last actually changed." Helps both
CI and manual Mac runs.

## Safety (production — BBO extension depends on these)
Regenerated locally: `manifest-{release,beta,test}.json` come out **byte-for-byte
identical** (with the guard, even the SHA is preserved), so the extension is
unaffected. `manifest-release-test.json` builds cleanly (334 scenarios + 4
`testScenarios`). Manifests are **not** hand-committed — the Action regenerates
them on merge (it triggers on `py/build_manifest.py`).

Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)