### PR TITLE
Manifest v2: lessons roster + rotation-canonical board-version token (#179)

### DIFF
--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -11,7 +11,9 @@ on:
       - 'btn/**'
       - 'pbs-release/**'
       - 'pbs-test/**'
+      - 'coaching-non-rotated/**'
       - 'py/build_manifest.py'
+      - 'py/board_version_token.py'
       - '.github/workflows/build-manifest.yml'
   workflow_dispatch:
 

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -33,11 +33,16 @@ version overrides `pbs-release`.
 > Tiers are keyed by name (`release`/`beta`/`test`/`release-test`); the existing
 > three are byte-for-byte unchanged (the BBO extension keeps working).
 
-## Schema (`schemaVersion: 1`)
+## Schema (`schemaVersion: 2`)
+
+**v2 (PBS #179 / Bridge-Classroom ADR-0002, producer-contract R5):** adds the
+`lessons` roster — the authoritative per-board description of the
+Bridge-Classroom-served coaching collection (`coaching-non-rotated/`). The
+`layout`/`scenarios`/`deltas`/`counts` blocks are unchanged from v1.
 
 ```jsonc
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "tier": "release",
   "generatedAtCommit": "<sha>",
   "sources": { "layout": "btn/-button-layout-release.txt", "pbs": ["pbs-release"] },
@@ -67,6 +72,19 @@ version overrides `pbs-release`.
     }
   },
 
+  "lessons": {                   // v2 — keyed by PBN basename (= BC deal_subfolder)
+    "Finesse_Simple": {
+      "skillPath": "uncategorized",   // lesson-level default (mode of board paths)
+      "boardCount": 30,               // derived convenience
+      "stableBoardCount": 0,          // derived convenience
+      "boards": [                     // one entry per board, positional order
+        { "number": 1, "stable": false,
+          "boardVersionToken": "0dad5f56…",  // R3 rotation-canonical hash
+          "skillPath": "uncategorized" }
+      ]
+    }
+  },
+
   "deltas": {
     "missing": ["..."],          // referenced in layout, no .pbs  (was: red MISSING PBS FILES)
     "orphans": ["..."]           // .pbs present, not in layout    (was: purple ORPHAN SCENARIOS)
@@ -82,6 +100,23 @@ version overrides `pbs-release`.
 they are byte-for-byte what the menu renders today (wide commas, `!C` suit
 tokens, `\n` continuations preserved). `gibWorks`/`bbaWorks`/convention cards
 come from the `.btn` header — the layout has never carried them before.
+
+### `lessons` roster (v2)
+
+Built from `coaching-non-rotated/*.pbn` (one file per lesson), identical across
+all tiers — the coaching collection is tier-independent, but BC treats the
+**`release`** manifest as authoritative for mastery. Per-board fields:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `number` | `[Board]` | positional identity (mastery key with lesson) |
+| `stable` | `[Stable]` over file `%bridge-classroom-stable:` | **absent ⇒ `false`** (prerelease). BC derives `prerelease = !stable`. |
+| `boardVersionToken` | computed ([`board_version_token.py`](../py/board_version_token.py)) | R3 rotation-canonical `sha256` of the canonical deal+auction; opaque to BC. Computed from the extracted deal/auction — boards don't yet carry the `[BoardVersionToken]` tag (the R3 back-stamp is a separate step). |
+| `skillPath` | `[SkillPath]` | `uncategorized` allowed while prerelease (R4). |
+
+Lesson-level `skillPath` is the most common board path (a default); `boardCount`
+/ `stableBoardCount` are derived conveniences. Per contract §7 the **collection
+id, `report` flag, and `prerelease` column are BC's — we do not emit them.**
 
 ## Consumer refactor map (PBS #167, part 3)
 

--- a/py/board_version_token.py
+++ b/py/board_version_token.py
@@ -21,8 +21,9 @@ Normalization (defined here — opaque to BC, so this file IS the definition):
   * canonical_deal   -> "N:<h0> <h1> <h2> <h3>", hands clockwise from the ♠A
     holder (N,E,S,W); each hand uppercased with ranks sorted A→2 within each suit.
   * canonical_auction-> "<dealer>:<call> <call> …", dealer = rotated dealer seat
-    letter; calls uppercased, in order, alerts/annotations stripped, PASS/X/XX
-    preserved.
+    letter; calls uppercased, in order, PASS/X/XX preserved, notrump collapsed to
+    one form (`3N`==`3NT`). Alerts (`=n=`) / annotations (`!`,`?`) are stripped;
+    any OTHER unrecognized token raises (so variance can't silently churn a token).
 
 Pure stdlib (runs unchanged in GitHub Actions and on the Mac).
 """
@@ -31,7 +32,9 @@ import re
 
 _SEATS = "NESW"
 _RANK_ORDER = "AKQJT98765432"
-_CALL_RE = re.compile(r"^(?:PASS|X|XX|[1-7](?:C|D|H|S|N|NT))$")
+_BID_RE = re.compile(r"^([1-7])(C|D|H|S|NT|N)$")
+_ALERT_RE = re.compile(r"^=\d+=$")   # BBA alert marker — not a call
+_ANNOT_RE = re.compile(r"^[!?]+$")    # PBN call annotation (!, ?, !!) — not a call
 
 
 def _norm_hand(hand):
@@ -67,15 +70,30 @@ def _spade_ace_seat(hands):
 
 
 def normalize_calls(tokens):
-    """Filter a raw auction token stream to canonical calls (PASS/X/XX/bids)."""
+    """Raw auction token stream -> canonical calls (PASS/X/XX/bids).
+
+    Two hardenings so the (once-locked) token can't drift on future data-entry
+    variance:
+      * notrump is canonicalized to one form: `3N` and `3NT` both -> `3NT`.
+      * a token that is neither a call nor a KNOWN-droppable annotation (BBA
+        `=n=` alert, PBN `!`/`?`) RAISES, rather than being silently dropped —
+        so a stray/typo'd call surfaces loudly instead of changing the hash.
+    """
     calls = []
     for t in tokens:
         u = t.strip().upper()
         if not u:
             continue
-        if _CALL_RE.match(u):
+        if u in ("PASS", "X", "XX"):
             calls.append(u)
-        # else: alert (=n=), '!'/'?' annotations, comments -> dropped
+            continue
+        m = _BID_RE.match(u)
+        if m:
+            calls.append(m.group(1) + ("NT" if m.group(2) == "N" else m.group(2)))
+            continue
+        if _ALERT_RE.match(u) or _ANNOT_RE.match(u):
+            continue  # alert / annotation — legitimately not a call
+        raise ValueError(f"unrecognized auction token: {t!r}")
     return calls
 
 
@@ -117,3 +135,15 @@ if __name__ == "__main__":
         print(f"  rot {r}: dealer={rdealer} token={t} {'OK' if t == base else 'MISMATCH'}")
         ok = ok and (t == base)
     print("rotation-invariant:", ok)
+
+    # Hardening checks: NT canonicalization + raise on unrecognized token.
+    nt_deal = "N:AKQ.234.567.8TJ 234.567.8TJ.9QK 567.89T.JQK.A23 89T.AKQ.234.456"
+    assert (board_version_token(nt_deal, "N", normalize_calls("3N PASS PASS PASS".split()))
+            == board_version_token(nt_deal, "N", normalize_calls("3NT PASS PASS PASS".split()))), \
+        "3N and 3NT must collapse to the same token"
+    try:
+        normalize_calls(["1H", "ZZ", "PASS"])
+        raise AssertionError("expected ValueError on unrecognized token")
+    except ValueError:
+        pass
+    print("NT-collapse + raise-on-unknown: OK")

--- a/py/board_version_token.py
+++ b/py/board_version_token.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+board_version_token.py — R3 rotation-canonical board-version token.
+
+The Bridge-Classroom producer contract (coaching-non-rotated/CLAUDE.md, R3)
+requires a per-board content-identity stamp that is INVARIANT to table rotation:
+every rotation of the same deal+auction maps to the same token. BC treats it as
+opaque — it records the token and echoes it into "Report a Problem" but never
+computes, verifies, or compares it. There is exactly one implementation of the
+scheme: this one.
+
+Algorithm (per the contract):
+  1. Find the seat holding the ♠A (every deal has exactly one).
+  2. Rotate so that holder → North (apply the SAME rotation k to the hands and to
+     the auction: calls keep their order, only the dealer/seat label shifts by k).
+  3. token = sha256( normalize(canonical_deal) + "|" + normalize(canonical_auction) )
+     lowercase hex, computed over EXTRACTED values (not raw file bytes), so
+     cosmetic reformatting never churns the token.
+
+Normalization (defined here — opaque to BC, so this file IS the definition):
+  * canonical_deal   -> "N:<h0> <h1> <h2> <h3>", hands clockwise from the ♠A
+    holder (N,E,S,W); each hand uppercased with ranks sorted A→2 within each suit.
+  * canonical_auction-> "<dealer>:<call> <call> …", dealer = rotated dealer seat
+    letter; calls uppercased, in order, alerts/annotations stripped, PASS/X/XX
+    preserved.
+
+Pure stdlib (runs unchanged in GitHub Actions and on the Mac).
+"""
+import hashlib
+import re
+
+_SEATS = "NESW"
+_RANK_ORDER = "AKQJT98765432"
+_CALL_RE = re.compile(r"^(?:PASS|X|XX|[1-7](?:C|D|H|S|N|NT))$")
+
+
+def _norm_hand(hand):
+    """Uppercase a 'S.H.D.C' hand and sort ranks A→2 within each suit."""
+    suits = hand.split(".")
+    out = []
+    for s in suits:
+        cs = sorted(s.upper(), key=lambda c: _RANK_ORDER.index(c)
+                    if c in _RANK_ORDER else len(_RANK_ORDER))
+        out.append("".join(cs))
+    return ".".join(out)
+
+
+def parse_deal(deal):
+    """PBN [Deal] value -> [N_hand, E_hand, S_hand, W_hand] (seat order)."""
+    prefix, rest = deal.split(":", 1)
+    start = _SEATS.index(prefix.strip()[-1].upper())
+    hands = rest.split()
+    if len(hands) != 4:
+        raise ValueError(f"expected 4 hands, got {len(hands)}: {deal!r}")
+    by_seat = {}
+    for i, h in enumerate(hands):
+        by_seat[_SEATS[(start + i) % 4]] = h
+    return [by_seat["N"], by_seat["E"], by_seat["S"], by_seat["W"]]
+
+
+def _spade_ace_seat(hands):
+    """Index (0=N..3=W) of the hand holding the ♠A."""
+    for i, h in enumerate(hands):
+        if "A" in h.split(".")[0].upper():
+            return i
+    raise ValueError(f"no ♠A found in {hands!r}")
+
+
+def normalize_calls(tokens):
+    """Filter a raw auction token stream to canonical calls (PASS/X/XX/bids)."""
+    calls = []
+    for t in tokens:
+        u = t.strip().upper()
+        if not u:
+            continue
+        if _CALL_RE.match(u):
+            calls.append(u)
+        # else: alert (=n=), '!'/'?' annotations, comments -> dropped
+    return calls
+
+
+def board_version_token(deal, dealer, calls):
+    """Return the lowercase-hex rotation-canonical token for one board.
+
+    deal   : PBN [Deal] value, e.g. "N:T75.KJ2.A872.J92 K842.3.JT5.AQT64 …"
+    dealer : dealer seat letter (from [Auction "S"] or [Dealer]); '' tolerated.
+    calls  : already-normalized list of calls (use normalize_calls first).
+    """
+    hands = parse_deal(deal)
+    s = _spade_ace_seat(hands)
+    canon_hands = [_norm_hand(hands[(s + j) % 4]) for j in range(4)]
+    canonical_deal = "N:" + " ".join(canon_hands)
+    d = _SEATS.index(dealer.strip().upper()) if dealer and dealer.strip().upper() in _SEATS else 0
+    canonical_dealer = _SEATS[(d - s) % 4]
+    canonical_auction = canonical_dealer + ":" + " ".join(calls)
+    payload = canonical_deal + "|" + canonical_auction
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+if __name__ == "__main__":
+    # Self-test: determinism + rotation invariance.
+    deal = "N:T75.KJ2.A872.J92 K842.3.JT5.AQT64 AQ9.QT854.KQ43.K J63.A976.96.8753"
+    dealer, calls = "S", ["1H", "PASS", "2H", "PASS", "3H", "PASS", "4H", "PASS", "PASS", "PASS"]
+    base = board_version_token(deal, dealer, calls)
+    print("token:", base)
+
+    def rotate_deal(dl, r):
+        hands = parse_deal(dl)  # N,E,S,W
+        rot = [hands[(i - r) % 4] for i in range(4)]  # physical table rotation
+        return "N:" + " ".join(rot)
+
+    ok = True
+    for r in range(4):
+        rd = rotate_deal(deal, r)
+        rdealer = _SEATS[(_SEATS.index(dealer) + r) % 4]
+        t = board_version_token(rd, rdealer, calls)
+        print(f"  rot {r}: dealer={rdealer} token={t} {'OK' if t == base else 'MISMATCH'}")
+        ok = ok and (t == base)
+    print("rotation-invariant:", ok)

--- a/py/build_manifest.py
+++ b/py/build_manifest.py
@@ -380,7 +380,11 @@ def build_lessons():
 
         boards = []
         for chunk in re.split(r'(?=\[Event )', raw):
-            b = _parse_coaching_board(chunk)
+            try:
+                b = _parse_coaching_board(chunk)   # normalize_calls may raise
+            except ValueError as e:
+                bn = re.search(r'\[Board "(\d+)"\]', chunk)
+                raise ValueError(f"{fn} board {bn.group(1) if bn else '?'}: {e}") from e
             if not b:
                 continue
             stable = file_stable if b["stable_tag"] is None else (b["stable_tag"] == "true")

--- a/py/build_manifest.py
+++ b/py/build_manifest.py
@@ -43,12 +43,22 @@ import os
 import re
 import subprocess
 import sys
+from collections import Counter
 
-SCHEMA_VERSION = 1
+# The manifest build runs under `python3 -P` / PYTHONSAFEPATH=1 (see the workflow
+# and py/select.py stdlib-shadow note), which drops this script's own directory
+# from sys.path — so re-add it explicitly for the sibling import below.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from board_version_token import board_version_token, normalize_calls  # noqa: E402
+
+SCHEMA_VERSION = 2
 
 # Repo root = parent of this file's directory (py/).
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BTN_DIR = os.path.join(ROOT, "btn")
+# Bridge-Classroom-served coaching collection: source of the v2 `lessons` roster
+# (producer contract R5). One .pbn per lesson; key = PBN basename.
+COACHING_DIR = os.path.join(ROOT, "coaching-non-rotated")
 
 # tier -> (layout filename, list of pbs source dirs [primary first])
 #
@@ -313,6 +323,91 @@ def parse_layout(layout_path):
 
 
 # --------------------------------------------------------------------------- #
+# lessons roster (schema v2 — producer contract R5)
+#
+# Authoritative per-board description of the Bridge-Classroom-served coaching
+# collection. Keyed by PBN basename (= the deal_subfolder BC stores on
+# observations). Each board carries number / stable / boardVersionToken /
+# skillPath. Per contract §7 the collection id, `report` flag and `prerelease`
+# column stay BC's — we do NOT emit them.
+#
+#   stable            : from `[Stable]` (board) over `%bridge-classroom-stable:`
+#                       (file). ABSENT ⇒ false (prerelease) — the safe default.
+#   boardVersionToken : R3 rotation-canonical hash, computed here from the
+#                       extracted deal + auction (board_version_token.py). Boards
+#                       do not yet carry the `[BoardVersionToken]` tag (the R3
+#                       back-stamp build step is a separate follow-up); computing
+#                       it in the manifest is equivalent and needs no file edits.
+#   skillPath         : from `[SkillPath]`; `uncategorized` while prerelease (R4).
+# --------------------------------------------------------------------------- #
+def _parse_coaching_board(text):
+    """One board chunk -> roster fields, or None if it isn't a board."""
+    bnum = re.search(r'\[Board "(\d+)"\]', text)
+    deal = re.search(r'\[Deal "([^"]+)"\]', text)
+    if not bnum or not deal:
+        return None
+    skill = re.search(r'\[SkillPath "([^"]*)"\]', text)
+    stable = re.search(r'\[Stable "([^"]*)"\]', text)
+    am = re.search(r'\[Auction "([^"]*)"\]\n(.*?)(?=\n\[|\n\{|\Z)', text, re.S)
+    if am:
+        dealer, calls = am.group(1), normalize_calls(am.group(2).split())
+    else:
+        dm = re.search(r'\[Dealer "([^"]*)"\]', text)
+        dealer, calls = (dm.group(1) if dm else ""), []
+    return {
+        "number": int(bnum.group(1)),
+        "stable_tag": stable.group(1).strip().lower() if stable else None,
+        "skillPath": skill.group(1) if skill else None,
+        "deal": deal.group(1),
+        "dealer": dealer,
+        "calls": calls,
+    }
+
+
+def build_lessons():
+    """Build the `lessons` roster from coaching-non-rotated/*.pbn."""
+    lessons = {}
+    if not os.path.isdir(COACHING_DIR):
+        return lessons
+    for fn in sorted(os.listdir(COACHING_DIR)):
+        if not fn.endswith(".pbn"):
+            continue
+        with open(os.path.join(COACHING_DIR, fn), encoding="utf-8") as fh:
+            raw = fh.read()
+        header = raw.split("[Event", 1)[0]
+        fm = re.search(r'%\s*bridge-classroom-stable:\s*(true|false)', header, re.I)
+        file_stable = bool(fm) and fm.group(1).lower() == "true"
+
+        boards = []
+        for chunk in re.split(r'(?=\[Event )', raw):
+            b = _parse_coaching_board(chunk)
+            if not b:
+                continue
+            stable = file_stable if b["stable_tag"] is None else (b["stable_tag"] == "true")
+            try:
+                token = board_version_token(b["deal"], b["dealer"], b["calls"])
+            except ValueError:
+                token = None  # malformed deal — surface as null rather than crash
+            boards.append({
+                "number": b["number"],
+                "stable": stable,
+                "boardVersionToken": token,
+                "skillPath": b["skillPath"] or "uncategorized",
+            })
+        if not boards:
+            continue
+        # lesson-level default = most common board skillPath (positional tie-break).
+        lesson_skill = Counter(x["skillPath"] for x in boards).most_common(1)[0][0]
+        lessons[fn[:-4]] = {
+            "skillPath": lesson_skill,
+            "boardCount": len(boards),
+            "stableBoardCount": sum(1 for x in boards if x["stable"]),
+            "boards": boards,  # positional order (file order)
+        }
+    return lessons
+
+
+# --------------------------------------------------------------------------- #
 # manifest assembly
 # --------------------------------------------------------------------------- #
 def list_pbs(dir_name):
@@ -355,7 +450,7 @@ def git_sha():
         return None
 
 
-def build_tier(tier, btn_meta):
+def build_tier(tier, btn_meta, lessons):
     layout_name, pbs_dirs = TIERS[tier]
     layout_path = os.path.join(BTN_DIR, layout_name)
     items, referenced = parse_layout(layout_path)
@@ -389,6 +484,8 @@ def build_tier(tier, btn_meta):
         "sources": {"layout": f"btn/{layout_name}", "pbs": pbs_dirs},
         "layout": items,
         "scenarios": scenarios,
+        # v2 producer-contract R5 roster (tier-independent — coaching collection).
+        "lessons": lessons,
         "deltas": {"missing": sorted(missing), "orphans": orphans},
         "counts": {
             "referenced": len(referenced),
@@ -423,13 +520,19 @@ def main():
     args = ap.parse_args()
 
     btn_meta = load_all_btn_metadata()
+    lessons = build_lessons()  # tier-independent; compute once, share across tiers
     tiers = [args.tier] if args.tier else sorted(TIERS)
     out_dir = os.path.join(ROOT, args.out_dir)
     if not args.check:
         os.makedirs(out_dir, exist_ok=True)
 
+    lesson_boards = sum(l["boardCount"] for l in lessons.values())
+    lesson_stable = sum(l["stableBoardCount"] for l in lessons.values())
+    print(f"[lessons] {len(lessons)} lessons, {lesson_boards} boards "
+          f"({lesson_stable} stable)")
+
     for tier in tiers:
-        m = build_tier(tier, btn_meta)
+        m = build_tier(tier, btn_meta, lessons)
         c = m["counts"]
         print(f"[{tier}] referenced={c['referenced']} "
               f"missing={c['missing']} orphans={c['orphans']}"


### PR DESCRIPTION
Implements #179 (Bridge-Classroom ADR-0002 / producer-contract R5): adds the authoritative per-board `lessons` roster to the deal-source manifest, keyed by PBN basename.

## Changes
- **`py/board_version_token.py`** (new) — the R3 rotation-canonical board-version token. Pure stdlib (the manifest builds in a GitHub Action). `python3 py/board_version_token.py` runs a self-test proving rotation-invariance across all four seat rotations.
- **`py/build_manifest.py`** — `schemaVersion` → **2**; new `lessons` roster from `coaching-non-rotated/*.pbn`; per board `number` / `stable` / `boardVersionToken` / `skillPath`, plus lesson-level `skillPath` / `boardCount` / `stableBoardCount`. `layout`/`scenarios`/`deltas`/`counts` unchanged; roster included in every tier (BC treats `release` as authoritative).
- **`.github/workflows/build-manifest.yml`** — added `coaching-non-rotated/**` and the new module to the rebuild triggers.
- **`manifest/README.md`** — v2 schema documentation.

The four `manifest-*.json` are **not** in this PR — repo convention is that CI generates and commits them. Merging this triggers `build-manifest.yml`, which regenerates them (verified idempotent locally). To preview: `python3 -P py/build_manifest.py`.

## Q (from review): is the auction in the hash? — **yes**
Token = `sha256(canonical_deal + "|" + canonical_auction)`, with **both** the deal and the auction rotated to ♠A-North. Evidence:
- **Positive test:** same hands, *different* auction → *different* token. So different-auction-same-deal boards do **not** collide.
- **The 13 cross-lesson dups are legit same-content reuse.** e.g. `Basic_NT#4` vs `Basic_NT_Defense_LHO#16`: raw deal string and dealer differ, but the **canonical deal and canonical auction are byte-identical** — the same board shown from a different seat (offense vs its LHO-defense counterpart). The token correctly collapses the rotation. **0 intra-lesson** collisions.

## Validation
66 lessons / 1517 boards; every board carries all four fields; all tokens valid 64-hex lowercase; rebuild byte-identical (idempotent).

## Prerelease-by-default (correct, not a gap)
Nothing is promoted yet, so `stable=false` everywhere and `stableBoardCount: 0`; `skillPath` is `uncategorized` where untagged (the 8 defense lessons carry real paths). Contract-legal while prerelease. Promotion (flipping `stable=true` + assigning skill paths) is a separate curation call, out of scope here.

## #175 (`.pbn` back-stamp) — producer side supports descope
The token is computed in the manifest and keyed by `(basename, number)`, so BC can **manifest-join** to get a board's token instead of reading a `[BoardVersionToken]` tag off the served PBN. Scanned this repo **and** the AI-Bridge-Play-Trainer: **no consumer reads the token outside the manifest** — only the producer/CI/contract-docs reference it, and the play-trainer reads `coaching/` (not `coaching-non-rotated/`) and uses no tokens. So from the producer side, #175 can be dropped in favor of manifest-join. Until that lands, BC records null `board_version_token` on observations (the served PBNs have no tag) — fine for roster/sizing; only the report flow carries null until the join closes it.

Closes #179.
